### PR TITLE
Fix incorrect "Should print:" comment in ExampleStrictPolicy().

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -133,9 +133,10 @@ func ExampleNewPolicy() {
 		`<a onblur="alert(secret)" href="http://www.google.com">Google</a>`,
 	)
 
-	// Should print:
-	// <a href="http://www.google.com" rel="nofollow">Google</a>
 	fmt.Println(html)
+
+	// Output:
+	//<a href="http://www.google.com" rel="nofollow">Google</a>
 }
 
 func ExampleStrictPolicy() {
@@ -145,9 +146,10 @@ func ExampleStrictPolicy() {
 		`Goodbye <a onblur="alert(secret)" href="http://en.wikipedia.org/wiki/Goodbye_Cruel_World_(Pink_Floyd_song)">Cruel</a> World`,
 	)
 
-	// Should print:
-	// Hello  World
 	fmt.Println(html)
+
+	// Output:
+	//Goodbye  World
 }
 
 func ExampleUGCPolicy() {
@@ -157,7 +159,8 @@ func ExampleUGCPolicy() {
 		`<a onblur="alert(secret)" href="http://www.google.com">Google</a>`,
 	)
 
-	// Should print:
-	// <a href="http://www.google.com" rel="nofollow">Google</a>
 	fmt.Println(html)
+
+	// Output:
+	//<a href="http://www.google.com" rel="nofollow">Google</a>
 }


### PR DESCRIPTION
The "Should print:" comment in ExampleStrictPolicy() suggested the output should be "Hello  World", which is incorrect, as the actual output is "Goodbye  World".

Change examples to use concluding "Output:" line comment, which is then compared to actual standard output of the function when when the tests are run. That way, such a mistake would not occur without being noticed. See http://godoc.org/testing#hdr-Examples for reference.
