### PR TITLE
Add AllowURLSchemeWithCustomPolicy() to allow external fine grain control over allowed URLs.

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -313,7 +313,7 @@ func (p *Policy) validURL(rawurl string) (string, bool) {
 		}
 
 		if u.Scheme != "" {
-			if _, ok := p.setOfUrlSchemes[u.Scheme]; ok {
+			if urlPolicy, ok := p.allowUrlSchemes[u.Scheme]; ok && (urlPolicy == nil || urlPolicy(u) == true) {
 				return u.String(), true
 			}
 


### PR DESCRIPTION
Closes #6.
- Fix typo "schems" -> "schemes" in docs for AllowURLSchemes.
- Don't make urlPolicy type exported to keep public API bloat minimum.

Feedback absolutely welcome, I am open for changes. Let me know what you think.
