### PR TITLE
Use new golang.org/x/... import paths.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ go:
   - tip
 
 install:
-  - go get code.google.com/p/go.net/html
+  - go get golang.org/x/net/html
 
 script: go test -v ./...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ If you are reporting a security flaw, you may expect that we will provide the co
 * Describe the reason for the pull request and if applicable show some example inputs and outputs to demonstrate what the patch does
 * Fork the repository on Github
 * Before submitting the pull request you should
-  1. Include tests for your patch, 1 test should encapsulate the entire patch and should refer to the Github issue 
+  1. Include tests for your patch, 1 test should encapsulate the entire patch and should refer to the Github issue
   1. If you have added new exposed/public functionality, you should ensure it is documented appropriately
   1. If you have added new exposed/public functionality, you should consider demonstrating how to use it within one of the helpers or shipped policies if appropriate or within a test if modifying a helper or policy is not appropriate
   1. Run all of the tests `go test -v ./...` or `make test` and ensure all tests pass

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ bluemonday is heavily inspired by both the [OWASP Java HTML Sanitizer](https://c
 
 Whitelist based, you need to either build a policy describing the HTML elements and attributes to permit (and the `regexp` patterns of attributes), or use one of the supplied policies representing good defaults.
 
-The policy containing the whitelist is applied using a fast non-validating, forward only, token-based parser implemented in the [Go net/html library](https://code.google.com/p/go/source/browse/?repo=net#hg%2Fhtml) by the core Go team.
+The policy containing the whitelist is applied using a fast non-validating, forward only, token-based parser implemented in the [Go net/html library](https://godoc.org/golang.org/x/net/html) by the core Go team.
 
 We expect to be supplied with well-formatted HTML (closing elements for every applicable open element, nested correctly) and so we do not focus on repairing badly nested or incomplete HTML. We focus on simply ensuring that whatever elements do exist are described in the policy whitelist and that attributes and links are safe for use on your web page. [GIGO](http://en.wikipedia.org/wiki/Garbage_in,_garbage_out) does apply and if you feed it bad HTML bluemonday is not tasked with figuring out how to make it good again.
 
@@ -60,7 +60,7 @@ We expect to be supplied with well-formatted HTML (closing elements for every ap
 
 bluemonday is regularly tested against Go 1.1, 1.2, 1.3 and tip.
 
-We do not support Go 1.0 as we depend on `code.google.com/p/go.net/html` which includes a reference to `io.ErrNoProgress` which did not exist in Go 1.0.
+We do not support Go 1.0 as we depend on `golang.org/x/net/html` which includes a reference to `io.ErrNoProgress` which did not exist in Go 1.0.
 
 ## Is it production ready?
 
@@ -123,7 +123,7 @@ func main() {
 	// Require URLs to be parseable by net/url.Parse and either:
 	//   mailto: http:// or https://
 	p.AllowStandardURLs()
-	
+
 	// We only allow <p> and <a href="">
 	p.AllowAttrs("href").OnElements("a")
 	p.AllowElements("p")
@@ -312,7 +312,7 @@ It is not the job of bluemonday to fix your bad HTML, it is merely the job of bl
 
 If you have cloned this repo you will probably need the dependency:
 
-`go get code.google.com/p/go.net/html`
+`go get golang.org/x/net/html`
 
 Gophers can use their familiar tools:
 

--- a/sanitize.go
+++ b/sanitize.go
@@ -35,7 +35,7 @@ import (
 	"net/url"
 	"strings"
 
-	"code.google.com/p/go.net/html"
+	"golang.org/x/net/html"
 )
 
 // Sanitize takes a string that contains a HTML fragment or document and applies


### PR DESCRIPTION
See http://golang.org/s/go14subrepo.

Trim (unnecessary) trailing whitespace.

I've also changed the `golang.org/x/net/html` package link in `README.md` to point to the godoc rather than its source (which can be navigated to from godoc), since that is a more presentable way to view a package. I hope that's okay.
