### PR TITLE
Update urls in tests for consistency.

### DIFF
--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1250,8 +1250,8 @@ func TestIssue9(t *testing.T) {
 	}
 
 	tt = test{
-		in:       `<h2><a name="git-diff" class="anchor" href="https://github.com/shurcooL/go/blob/master/github_flavored_markdown/sanitize_test.go" aria-hidden="true"><span class="octicon octicon-link"></span></a>git diff</h2>`,
-		expected: `<h2><a name="git-diff" class="anchor" href="https://github.com/shurcooL/go/blob/master/github_flavored_markdown/sanitize_test.go" aria-hidden="true" rel="nofollow" target="_blank"><span class="octicon octicon-link"></span></a>git diff</h2>`,
+		in:       `<h2><a name="git-diff" class="anchor" href="https://github.com/shurcooL/github_flavored_markdown/blob/master/sanitize_test.go" aria-hidden="true"><span class="octicon octicon-link"></span></a>git diff</h2>`,
+		expected: `<h2><a name="git-diff" class="anchor" href="https://github.com/shurcooL/github_flavored_markdown/blob/master/sanitize_test.go" aria-hidden="true" rel="nofollow" target="_blank"><span class="octicon octicon-link"></span></a>git diff</h2>`,
 	}
 	out = p.Sanitize(tt.in)
 	if out != tt.expected {
@@ -1264,8 +1264,8 @@ func TestIssue9(t *testing.T) {
 	}
 
 	tt = test{
-		in:       `<h2><a name="git-diff" class="anchor" href="https://github.com/shurcooL/go/blob/master/github_flavored_markdown/sanitize_test.go" aria-hidden="true" target="namedwindow"><span class="octicon octicon-link"></span></a>git diff</h2>`,
-		expected: `<h2><a name="git-diff" class="anchor" href="https://github.com/shurcooL/go/blob/master/github_flavored_markdown/sanitize_test.go" aria-hidden="true" rel="nofollow" target="_blank"><span class="octicon octicon-link"></span></a>git diff</h2>`,
+		in:       `<h2><a name="git-diff" class="anchor" href="https://github.com/shurcooL/github_flavored_markdown/blob/master/sanitize_test.go" aria-hidden="true" target="namedwindow"><span class="octicon octicon-link"></span></a>git diff</h2>`,
+		expected: `<h2><a name="git-diff" class="anchor" href="https://github.com/shurcooL/github_flavored_markdown/blob/master/sanitize_test.go" aria-hidden="true" rel="nofollow" target="_blank"><span class="octicon octicon-link"></span></a>git diff</h2>`,
 	}
 	out = p.Sanitize(tt.in)
 	if out != tt.expected {


### PR DESCRIPTION
The `github_flavored_markdown` package has moved out from `go` repository into its own in https://github.com/shurcooL/go/issues/19#issuecomment-102574426. Update urls in tests accordingly for consistency.

I hope you don't mind this pull request. I know that this is just test data, and it doesn't need to be a valid url at all. But I thought it'd be nice to update it, just to avoid pointing to the outdated import path and possibly confusing some people into thinking that may be the canonical import path.