### PR TITLE
Access to setOfElementsWithoutAttrs and setOfElementsToSkipContent

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -374,7 +374,7 @@ func (p *Policy) AllowDocType(allow bool) *Policy {
 
 // SkipElementContent adds the HTML elements whose tags is needed to be removed
 // with it's content.
-func (p *Policy) SkipElementContent(names ...string) *Policy {
+func (p *Policy) SkipElementsContent(names ...string) *Policy {
 
 	p.init()
 

--- a/policy.go
+++ b/policy.go
@@ -94,8 +94,9 @@ type attrPolicy struct {
 type attrPolicyBuilder struct {
 	p *Policy
 
-	attrNames []string
-	regexp    *regexp.Regexp
+	attrNames  []string
+	regexp     *regexp.Regexp
+	allowEmpty bool
 }
 
 type urlPolicy func(url *url.URL) (allowUrl bool)
@@ -136,13 +137,42 @@ func (p *Policy) AllowAttrs(attrNames ...string) *attrPolicyBuilder {
 
 	p.init()
 
-	abp := attrPolicyBuilder{p: p}
+	abp := attrPolicyBuilder{
+		p:          p,
+		allowEmpty: false,
+	}
 
 	for _, attrName := range attrNames {
 		abp.attrNames = append(abp.attrNames, strings.ToLower(attrName))
 	}
 
 	return &abp
+}
+
+// AllowNoAttrs says that attributes on element are optional.
+//
+// The attribute policy is only added to the core policy when OnElements(...)
+// are called.
+func (p *Policy) AllowNoAttrs() *attrPolicyBuilder {
+
+	p.init()
+
+	abp := attrPolicyBuilder{
+		p:          p,
+		allowEmpty: true,
+	}
+	return &abp
+}
+
+// AllowNoAttrs says that attributes on element are optional.
+//
+// The attribute policy is only added to the core policy when OnElements(...)
+// are called.
+func (abp *attrPolicyBuilder) AllowNoAttrs() *attrPolicyBuilder {
+
+	abp.allowEmpty = true
+
+	return abp
 }
 
 // Matching allows a regular expression to be applied to a nascent attribute
@@ -174,6 +204,14 @@ func (abp *attrPolicyBuilder) OnElements(elements ...string) *Policy {
 			}
 
 			abp.p.elsAndAttrs[element][attr] = ap
+		}
+
+		if abp.allowEmpty {
+			abp.p.setOfElementsWithoutAttrs[element] = struct{}{}
+
+			if _, ok := abp.p.elsAndAttrs[element]; !ok {
+				abp.p.elsAndAttrs[element] = make(map[string]attrPolicy)
+			}
 		}
 	}
 
@@ -330,6 +368,23 @@ func (p *Policy) AllowURLSchemeWithCustomPolicy(
 func (p *Policy) AllowDocType(allow bool) *Policy {
 
 	p.allowDocType = allow
+
+	return p
+}
+
+// SkipElementContent adds the HTML elements whose tags is needed to be removed
+// with it's content.
+func (p *Policy) SkipElementContent(names ...string) *Policy {
+
+	p.init()
+
+	for _, element := range names {
+		element = strings.ToLower(element)
+
+		if _, ok := p.setOfElementsToSkipContent[element]; !ok {
+			p.setOfElementsToSkipContent[element] = struct{}{}
+		}
+	}
 
 	return p
 }

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1277,3 +1277,60 @@ func TestIssue9(t *testing.T) {
 		)
 	}
 }
+
+func TestAllowNoAttrs(t *testing.T) {
+	input := "<tag>test</tag>"
+	outputFail := "test"
+	outputOk := input
+
+	p := Policy{}
+	p.AllowElements("tag")
+
+	if output := p.Sanitize(input); output != outputFail {
+		t.Errorf(
+			"test failed;\ninput   : %s\noutput  : %s\nexpected: %s",
+			input,
+			output,
+			outputFail,
+		)
+	}
+
+	p.AllowNoAttrs().OnElements("tag")
+
+	if output := p.Sanitize(input); output != outputOk {
+		t.Errorf(
+			"test failed;\ninput   : %s\noutput  : %s\nexpected: %s",
+			input,
+			output,
+			outputOk,
+		)
+	}
+}
+
+func TestSkipElementsContent(t *testing.T) {
+	input := "<tag>test</tag>"
+	outputFail := "test"
+	outputOk := ""
+
+	p := Policy{}
+
+	if output := p.Sanitize(input); output != outputFail {
+		t.Errorf(
+			"test failed;\ninput   : %s\noutput  : %s\nexpected: %s",
+			input,
+			output,
+			outputFail,
+		)
+	}
+
+	p.SkipElementsContent("tag")
+
+	if output := p.Sanitize(input); output != outputOk {
+		t.Errorf(
+			"test failed;\ninput   : %s\noutput  : %s\nexpected: %s",
+			input,
+			output,
+			outputOk,
+		)
+	}
+}


### PR DESCRIPTION
Closes #19

Added functions to Policy interface:
- AllowNoAttrs
- SkipElementsContent
to modify internal maps.

Use case:
Add some html tags that cannot have attributes without modification of policy.go default list. For example, "\<big>", "\<center>", etc. Or make attributes are optional.

Usage examples:
p.AllowNoAttrs().OnElements("big")
p.AllowAttrs("border", "cellpadding", "cellspacing").AllowNoAttrs().OnElements("table")
p.AllowNoAttrs().AllowAttrs("border", "cellpadding", "cellspacing").OnElements("table")
p.SkipElementsContent("style")