### PR TITLE
Resolves #33

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -50,6 +50,10 @@ type Policy struct {
 	// Allows the <!DOCTYPE > tag to exist in the sanitized document
 	allowDocType bool
 
+	// If true then we add spaces when stripping tags, specifically the closing
+	// tag is replaced by a space character.
+	addSpaces bool
+
 	// When true, add rel="nofollow" to HTML anchors
 	requireNoFollow bool
 
@@ -376,6 +380,23 @@ func (p *Policy) AllowURLSchemeWithCustomPolicy(
 func (p *Policy) AllowDocType(allow bool) *Policy {
 
 	p.allowDocType = allow
+
+	return p
+}
+
+// AddSpaceWhenStrippingTag states whether to add a single space " " when
+// removing tags that are not whitelisted by the policy.
+//
+// This is useful if you expect to strip tags in dense markup and may lose the
+// value of whitespace.
+//
+// For example: "<p>Hello</p><p>World</p>"" would be sanitized to "HelloWorld"
+// with the default value of false, but you may wish to sanitize this to
+// " Hello  World " by setting AddSpaceWhenStrippingTag to true as this would
+// retain the intent of the text.
+func (p *Policy) AddSpaceWhenStrippingTag(allow bool) *Policy {
+
+	p.addSpaces = allow
 
 	return p
 }

--- a/sanitize.go
+++ b/sanitize.go
@@ -130,6 +130,9 @@ func (p *Policy) sanitize(r io.Reader) *bytes.Buffer {
 					skipElementContent = true
 					skippingElementsCount++
 				}
+				if p.addSpaces {
+					buff.WriteString(" ")
+				}
 				break
 			}
 
@@ -141,6 +144,9 @@ func (p *Policy) sanitize(r io.Reader) *bytes.Buffer {
 				if !p.allowNoAttrs(token.Data) {
 					skipClosingTag = true
 					closingTagToSkipStack = append(closingTagToSkipStack, token.Data)
+					if p.addSpaces {
+						buff.WriteString(" ")
+					}
 					break
 				}
 			}
@@ -156,6 +162,9 @@ func (p *Policy) sanitize(r io.Reader) *bytes.Buffer {
 				if len(closingTagToSkipStack) == 0 {
 					skipClosingTag = false
 				}
+				if p.addSpaces {
+					buff.WriteString(" ")
+				}
 				break
 			}
 
@@ -165,6 +174,9 @@ func (p *Policy) sanitize(r io.Reader) *bytes.Buffer {
 					if skippingElementsCount == 0 {
 						skipElementContent = false
 					}
+				}
+				if p.addSpaces {
+					buff.WriteString(" ")
 				}
 				break
 			}
@@ -177,6 +189,9 @@ func (p *Policy) sanitize(r io.Reader) *bytes.Buffer {
 
 			aps, ok := p.elsAndAttrs[token.Data]
 			if !ok {
+				if p.addSpaces {
+					buff.WriteString(" ")
+				}
 				break
 			}
 
@@ -185,6 +200,9 @@ func (p *Policy) sanitize(r io.Reader) *bytes.Buffer {
 			}
 
 			if len(token.Attr) == 0 && !p.allowNoAttrs(token.Data) {
+				if p.addSpaces {
+					buff.WriteString(" ")
+				}
 				break
 			}
 


### PR DESCRIPTION
Option to add a single space in place of any tag that is removed by the
sanitization process. This allows text to be presented correctly within HTML
by not collapsing space when tags are removed.

i.e. "<foo>Hello</foo><bar>World</bar>" would sanitize as:
     "HelloWorld" without this option, but as:
     " Hello World " with this option.