### PR TITLE
Add center and marquee to whitelist

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -451,6 +451,7 @@ func (p *Policy) addDefaultElementsWithoutAttrs() {
 	p.setOfElementsAllowedWithoutAttrs["button"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["canvas"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["caption"] = struct{}{}
+	p.setOfElementsAllowedWithoutAttrs["center"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["cite"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["code"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["col"] = struct{}{}
@@ -484,6 +485,7 @@ func (p *Policy) addDefaultElementsWithoutAttrs() {
 	p.setOfElementsAllowedWithoutAttrs["kbd"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["li"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["mark"] = struct{}{}
+	p.setOfElementsAllowedWithoutAttrs["marquee"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["nav"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["ol"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["optgroup"] = struct{}{}


### PR DESCRIPTION
This will mean that if added in a policy, `<center>` and `<marquee>` can be used without attributes. Even though they're obsolete, the alternative would be whitelisting `<style>` or animations for our users.