### PR TITLE
Add ability to specify inline style policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,27 @@ p := bluemonday.UGCPolicy()
 p.AllowElements("fieldset", "select", "option")
 ```
 
+### Inline CSS
+
+Although it's possible to handle inline CSS using `AllowAttrs` with a `Matching` rule, writing a single monolithic regular expression to safely process all inline CSS which you wish to allow is not a trivial task.  Instead of attempting to do so, you can whitelist the `style` attribute on whichever element(s) you desire and use style policies to control and sanitize inline styles.
+
+As noted above for HTML attributes, it's **always** recommended that you use either `Matching` (with a suitable regular expression) or `MatchingEnum` to ensure that the value is safe. 
+
+Similar to attributes, you can allow specific CSS properties to be set inline:
+```go
+p.AllowAttrs("style").OnElements("span", "p")
+// Allow the 'color' property with valid RGB(A) hex values only (on any element allowed a 'style' attribute)
+p.AllowStyles("color").Matching(regexp.MustCompile("(?i)^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$")).Globally()
+```
+
+Additionally, you can allow a CSS property to be set only to an allowed value:
+```go
+p.AllowAttrs("style").OnElements("span", "p")
+// Allow the 'text-decoration' property to be set to 'underline', 'line-through' or 'none'
+// on 'span' elements only
+p.AllowStyles("text-decoration").MatchingEnum("underline", "line-through", "none").OnElements("span")
+```
+
 ### Links
 
 Links are difficult beasts to sanitise safely and also one of the biggest attack vectors for malicious content.

--- a/example_test.go
+++ b/example_test.go
@@ -191,6 +191,42 @@ func ExamplePolicy_AllowAttrs() {
 	).OnElements("td", "th")
 }
 
+func ExamplePolicy_AllowStyles() {
+	p := bluemonday.NewPolicy()
+
+	// Allow only 'span' and 'p' elements
+	p.AllowElements("span", "p", "strong")
+
+	// Only allow 'style' attributes on 'span' and 'p' elements
+	p.AllowAttrs("style").OnElements("span", "p")
+
+	// Allow the 'text-decoration' property to be set to 'underline', 'line-through' or 'none'
+	// on 'span' elements only
+	p.AllowStyles("text-decoration").MatchingEnum("underline", "line-through", "none").OnElements("span")
+
+	// Allow the 'color' property with valid RGB(A) hex values only
+	// on every HTML element that has been whitelisted
+	p.AllowStyles("color").Matching(regexp.MustCompile("(?i)^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$")).Globally()
+
+	// The span has an invalid 'color' which will be stripped along with other disallowed properties
+	html := p.Sanitize(
+		`<p style="color:#f00;">
+	<span style="text-decoration: underline; background-image: url(javascript:alert('XSS')); color: #f00ba">
+		Red underlined <strong style="text-decoration:none;">text</strong>
+	</span>
+</p>`,
+	)
+
+	fmt.Println(html)
+
+	// Output:
+	//<p style="color: #f00">
+	//	<span style="text-decoration: underline">
+	//		Red underlined <strong>text</strong>
+	//	</span>
+	//</p>
+}
+
 func ExamplePolicy_AllowElements() {
 	p := bluemonday.NewPolicy()
 

--- a/policy.go
+++ b/policy.go
@@ -79,6 +79,12 @@ type Policy struct {
 	// map[htmlAttributeName]attrPolicy
 	globalAttrs map[string]attrPolicy
 
+	// map[htmlElementName]map[cssPropertyName]stylePolicy
+	elsAndStyles map[string]map[string]stylePolicy
+
+	// map[cssPropertyName]stylePolicy
+	globalStyles map[string]stylePolicy
+
 	// If urlPolicy is nil, all URLs with matching schema are allowed.
 	// Otherwise, only the URLs with matching schema and urlPolicy(url)
 	// returning true are allowed.
@@ -103,12 +109,32 @@ type attrPolicy struct {
 	regexp *regexp.Regexp
 }
 
+type stylePolicy struct {
+
+	// optional pattern to match, when not nil the regexp needs to match
+	// otherwise the property is removed
+	regexp *regexp.Regexp
+
+	// optional list of allowed property values, for properties which
+	// have a defined list of allowed values; property will be removed
+	// if the value is not allowed
+	enum []string
+}
+
 type attrPolicyBuilder struct {
 	p *Policy
 
 	attrNames  []string
 	regexp     *regexp.Regexp
 	allowEmpty bool
+}
+
+type stylePolicyBuilder struct {
+	p *Policy
+
+	propertyNames []string
+	regexp        *regexp.Regexp
+	enum          []string
 }
 
 type urlPolicy func(url *url.URL) (allowUrl bool)
@@ -118,6 +144,8 @@ func (p *Policy) init() {
 	if !p.initialized {
 		p.elsAndAttrs = make(map[string]map[string]attrPolicy)
 		p.globalAttrs = make(map[string]attrPolicy)
+		p.elsAndStyles = make(map[string]map[string]stylePolicy)
+		p.globalStyles = make(map[string]stylePolicy)
 		p.allowURLSchemes = make(map[string]urlPolicy)
 		p.setOfElementsAllowedWithoutAttrs = make(map[string]struct{})
 		p.setOfElementsToSkipContent = make(map[string]struct{})
@@ -248,6 +276,98 @@ func (abp *attrPolicyBuilder) Globally() *Policy {
 	}
 
 	return abp.p
+}
+
+// AllowStyles takes a range of CSS property names and returns a
+// style policy builder that allows you to specify the pattern and scope of
+// the whitelisted property.
+//
+// The style policy is only added to the core policy when either Globally()
+// or OnElements(...) are called.
+func (p *Policy) AllowStyles(propertyNames ...string) *stylePolicyBuilder {
+
+	p.init()
+
+	abp := stylePolicyBuilder{
+		p: p,
+	}
+
+	for _, propertyName := range propertyNames {
+		abp.propertyNames = append(abp.propertyNames, strings.ToLower(propertyName))
+	}
+
+	return &abp
+}
+
+// Matching allows a regular expression to be applied to a nascent style
+// policy, and returns the style policy. Calling this more than once will
+// replace the existing regexp.
+func (spb *stylePolicyBuilder) Matching(regex *regexp.Regexp) *stylePolicyBuilder {
+
+	spb.regexp = regex
+
+	return spb
+}
+
+// MatchingEnum allows a list of allowed values to be applied to a nascent style
+// policy, and returns the style policy. Calling this more than once will
+// replace the existing list of allowed values.
+func (spb *stylePolicyBuilder) MatchingEnum(enum ...string) *stylePolicyBuilder {
+
+	spb.enum = enum
+
+	return spb
+}
+
+// OnElements will bind a style policy to a given range of HTML elements
+// and return the updated policy
+func (spb *stylePolicyBuilder) OnElements(elements ...string) *Policy {
+
+	for _, element := range elements {
+		element = strings.ToLower(element)
+
+		for _, attr := range spb.propertyNames {
+
+			if _, ok := spb.p.elsAndStyles[element]; !ok {
+				spb.p.elsAndStyles[element] = make(map[string]stylePolicy)
+			}
+
+			sp := stylePolicy{}
+			if spb.regexp != nil {
+				sp.regexp = spb.regexp
+			}
+			if len(spb.enum) > 0 {
+				sp.enum = spb.enum
+			}
+
+			spb.p.elsAndStyles[element][attr] = sp
+		}
+	}
+
+	return spb.p
+}
+
+// Globally will bind a style policy to all HTML elements and return the
+// updated policy
+func (spb *stylePolicyBuilder) Globally() *Policy {
+
+	for _, attr := range spb.propertyNames {
+		if _, ok := spb.p.globalStyles[attr]; !ok {
+			spb.p.globalStyles[attr] = stylePolicy{}
+		}
+
+		sp := stylePolicy{}
+		if spb.regexp != nil {
+			sp.regexp = spb.regexp
+		}
+		if len(spb.enum) > 0 {
+			sp.enum = spb.enum
+		}
+
+		spb.p.globalStyles[attr] = sp
+	}
+
+	return spb.p
 }
 
 // AllowElements will append HTML elements to the whitelist without applying an

--- a/sanitize.go
+++ b/sanitize.go
@@ -252,10 +252,26 @@ func (p *Policy) sanitizeAttrs(
 		return attrs
 	}
 
+	hasStylePolicies := false
+	sps, elementHasStylePolicies := p.elsAndStyles[elementName]
+	if len(p.globalStyles) > 0 || (elementHasStylePolicies && len(sps) > 0) {
+		hasStylePolicies = true
+	}
+
 	// Builds a new attribute slice based on the whether the attribute has been
 	// whitelisted explicitly or globally.
 	cleanAttrs := []html.Attribute{}
 	for _, htmlAttr := range attrs {
+		// Is this a "style" attribute, and if so, do we need to sanitize it?
+		if htmlAttr.Key == "style" && hasStylePolicies {
+			htmlAttr = p.sanitizeStyles(htmlAttr, sps)
+			if htmlAttr.Val == "" {
+				// We've sanitized away any and all styles; don't bother to
+				// output the style attribute (even if it's allowed)
+				continue
+			}
+		}
+
 		// Is there an element specific attribute policy that applies?
 		if ap, ok := aps[htmlAttr.Key]; ok {
 			if ap.regexp != nil {
@@ -483,6 +499,53 @@ func (p *Policy) sanitizeAttrs(
 	return cleanAttrs
 }
 
+func (p *Policy) sanitizeStyles(attr html.Attribute, sps map[string]stylePolicy) html.Attribute {
+	props := strings.Split(attr.Val, ";")
+	clean := []string{}
+
+	for _, prop := range props {
+		parts := strings.SplitN(prop, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		propName := strings.TrimSpace(parts[0])
+		propValue := strings.TrimSpace(parts[1])
+		if sp, ok := sps[propName]; ok {
+			if sp.regexp != nil {
+				if sp.regexp.MatchString(propValue) {
+					clean = append(clean, propName+": "+propValue)
+				}
+				continue
+			} else if len(sp.enum) > 0 && !stringInSlice(propValue, sp.enum) {
+				continue
+			}
+
+			clean = append(clean, propName+": "+propValue)
+		}
+
+		if sp, ok := p.globalStyles[propName]; ok {
+			if sp.regexp != nil {
+				if sp.regexp.MatchString(propValue) {
+					clean = append(clean, propName+": "+propValue)
+				}
+				continue
+			} else if len(sp.enum) > 0 && !stringInSlice(propValue, sp.enum) {
+				continue
+			}
+
+			clean = append(clean, propName+": "+propValue)
+		}
+	}
+
+	if len(clean) > 0 {
+		attr.Val = strings.Join(clean, "; ")
+	} else {
+		attr.Val = ""
+	}
+
+	return attr
+}
+
 func (p *Policy) allowNoAttrs(elementName string) bool {
 	_, ok := p.setOfElementsAllowedWithoutAttrs[elementName]
 	return ok
@@ -536,4 +599,14 @@ func linkable(elementName string) bool {
 	default:
 		return false
 	}
+}
+
+// stringInSlice returns true if needle exists in haystack
+func stringInSlice(needle string, haystack []string) bool {
+	for _, straw := range haystack {
+		if strings.ToLower(straw) == strings.ToLower(needle) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Following on from #43 / #44, I've implemented a policy type and builder for style policies, following the same pattern as attribute policies.  That means that you can whitelist individual CSS properties either globally (on any element that's had the `style` attribute whitelisted) or on specific elements.  In addition, a `MatchingEnum` method allows for a list of allowed values to be specified (useful for properties which have a set of predefined values, so that you don't need to build a regular expression to do this).

Note that this PR does not touch the predefined policies, though it does open the door to doing so in the future (either updating existing ones or adding new policies which include style policies).

It's currently implemented using simple string processing, rather than adding an external dependency; if that's deemed to be too naive or weak, the `sanitizeStyles` func in `sanitize.go` can be enhanced to use an actual parser (either an external dependency like douceur - as per #43 / #44 - or a custom minimal implementation to avoid external dependencies).

Closes #43.