### PR TITLE
Resolves #56 strings.ToLower() results in false match

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -480,6 +480,7 @@ func (p *Policy) addDefaultElementsWithoutAttrs() {
 	p.setOfElementsAllowedWithoutAttrs["ruby"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["s"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["samp"] = struct{}{}
+	p.setOfElementsAllowedWithoutAttrs["script"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["section"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["select"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["small"] = struct{}{}

--- a/sanitize.go
+++ b/sanitize.go
@@ -221,7 +221,7 @@ func (p *Policy) sanitize(r io.Reader) *bytes.Buffer {
 		case html.TextToken:
 
 			if !skipElementContent {
-				switch strings.ToLower(mostRecentlyStartedToken) {
+				switch mostRecentlyStartedToken {
 				case "script":
 					// not encouraged, but if a policy allows JavaScript we
 					// should not HTML escape it as that would break the output
@@ -235,7 +235,6 @@ func (p *Policy) sanitize(r io.Reader) *bytes.Buffer {
 					buff.WriteString(token.String())
 				}
 			}
-
 		default:
 			// A token that didn't exist in the html package when we wrote this
 			return &bytes.Buffer{}

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1644,3 +1644,43 @@ AAAASUVORK5CYII=" alt="">`
 			expected)
 	}
 }
+
+func TestIssue55ScriptTags(t *testing.T) {
+	p1 := NewPolicy()
+	p2 := UGCPolicy()
+	p3 := UGCPolicy().AllowElements("script")
+
+	in := `<SCRIPT>document.write('<h1><header/h1>')</SCRIPT>`
+	expected := ``
+	out := p1.Sanitize(in)
+	if out != expected {
+		t.Errorf(
+			"test failed;\ninput   : %s\noutput  : %s\nexpected: %s",
+			in,
+			out,
+			expected,
+		)
+	}
+
+	expected = ``
+	out = p2.Sanitize(in)
+	if out != expected {
+		t.Errorf(
+			"test failed;\ninput   : %s\noutput  : %s\nexpected: %s",
+			in,
+			out,
+			expected,
+		)
+	}
+
+	expected = `<script>document.write('<h1><header/h1>')</script>`
+	out = p3.Sanitize(in)
+	if out != expected {
+		t.Errorf(
+			"test failed;\ninput   : %s\noutput  : %s\nexpected: %s",
+			in,
+			out,
+			expected,
+		)
+	}
+}


### PR DESCRIPTION
Use of strings.ToLower() within the match for script or style handler for
TextToken results in unsanitized content being printed.