### PR TITLE
TokenReader for pre-sanitization transformations

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -103,19 +103,22 @@ func (p *Policy) sanitize(r io.Reader) *bytes.Buffer {
 	)
 
 	tokenizer := html.NewTokenizer(r)
+	reader := tokenizerReader{tokenizer}
 	for {
-		if tokenizer.Next() == html.ErrorToken {
-			err := tokenizer.Err()
+		token, err := reader.Token()
+		if token == nil {
 			if err == io.EOF {
 				// End of input means end of processing
 				return &buff
 			}
-
+			if err == nil {
+				// Skip nil token
+				continue
+			}
 			// Raw tokenizer error
 			return &bytes.Buffer{}
 		}
 
-		token := tokenizer.Token()
 		switch token.Type {
 		case html.DoctypeToken:
 

--- a/token.go
+++ b/token.go
@@ -32,6 +32,7 @@ package bluemonday
 import "golang.org/x/net/html"
 
 type TokenReader interface {
+	Source(source TokenReader)
 	Token() (*html.Token, error)
 }
 
@@ -47,4 +48,8 @@ func (r *tokenizerReader) Token() (*html.Token, error) {
 	}
 	token := r.Tokenizer.Token()
 	return &token, nil
+}
+
+// Source is a no-op for tokenizerReader
+func (r *tokenizerReader) Source(TokenReader) {
 }

--- a/token.go
+++ b/token.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2014, David Kitchen <david@buro9.com>
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the organisation (Microcosm) nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package bluemonday
+
+import "golang.org/x/net/html"
+
+type TokenReader interface {
+	Token() (*html.Token, error)
+}
+
+type tokenizerReader struct {
+	*html.Tokenizer
+}
+
+var _ TokenReader = &tokenizerReader{}
+
+func (r *tokenizerReader) Token() (*html.Token, error) {
+	if r.Next() == html.ErrorToken {
+		return nil, r.Err()
+	}
+	token := r.Tokenizer.Token()
+	return &token, nil
+}

--- a/token_test.go
+++ b/token_test.go
@@ -1,0 +1,48 @@
+package bluemonday
+
+import (
+	"testing"
+
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+)
+
+type testRemoverReader struct {
+	source  TokenReader
+	tagAtom atom.Atom
+}
+
+func (r *testRemoverReader) Token() (*html.Token, error) {
+	t, err := r.source.Token()
+	if err != nil {
+		return t, err
+	}
+	if (t.Type == html.StartTagToken || t.Type == html.EndTagToken) && t.DataAtom == r.tagAtom {
+		// Skip bold, return next token
+		return r.source.Token()
+	}
+	return t, nil
+}
+
+func (r *testRemoverReader) Source(s TokenReader) {
+	r.source = s
+}
+
+func TestTokenReader(t *testing.T) {
+	p := UGCPolicy()
+
+	input := "<p><b>A bold statement.</b></p>"
+	want := "<p><b>A bold statement.</b></p>"
+	got := p.Sanitize(input)
+	if got != want {
+		t.Errorf("got: %q, want: %q", got, want)
+	}
+
+	removeBold := &testRemoverReader{tagAtom: atom.B}
+	input = "<p><b>A bold statement.</b></p>"
+	want = "<p>A bold statement.</p>"
+	got = p.Sanitize(input, removeBold)
+	if got != want {
+		t.Errorf("got: %q, want: %q", got, want)
+	}
+}


### PR DESCRIPTION
Allows a chain of TokenReaders to manipulate the `html.Token` stream prior to bluemonday sanitizing it.

Closes #58 