### PR TITLE
Add address to DefaultElementsWithoutAttrs

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -440,6 +440,7 @@ func (p *Policy) addDefaultElementsWithoutAttrs() {
 
 	p.setOfElementsAllowedWithoutAttrs["abbr"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["acronym"] = struct{}{}
+	p.setOfElementsAllowedWithoutAttrs["address"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["article"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["aside"] = struct{}{}
 	p.setOfElementsAllowedWithoutAttrs["audio"] = struct{}{}


### PR DESCRIPTION
The `address` tag without attributes is safe. And we found in production that it was being stripped despite being present in the `AllowElements` list.