### PR TITLE
Support Go Modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,22 @@
 language: go
 go:
-  - 1.1
-  - 1.2
-  - 1.3
-  - 1.4
-  - 1.5
-  - 1.6
-  - 1.7
-  - 1.8
-  - 1.9
-  - 1.10
+  - 1.1.x
+  - 1.2.x
+  - 1.3.x
+  - 1.4.x
+  - 1.5.x
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
   - tip
 matrix:
   allow_failures:
     - go: tip
   fast_finish: true
 install:
-  - go get golang.org/x/net/html
+  - go get .
 script:
   - go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/microcosm-cc/bluemonday
+
+go 1.9
+
+require golang.org/x/net v0.0.0-20181220203305-927f97764cc3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/net v0.0.0-20181220203305-927f97764cc3 h1:eH6Eip3UpmR+yM/qI9Ijluzb1bNv/cAU/n+6l8tRSis=
+golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
Hello,

Please consider supporting [Go Modules], the new packaging standard that will be adopted fully in Go 1.12. Experimental support is in Go 1.11 and the new module paths are supported in Go 1.9.7+ and Go 1.10.3+ in a read-only manner for backwards compatibility with all supported versions of Go.

Because this library is still below version 2 and has few dependencies, the [`go.mod`] file is fairly simple. The only other thing that would need to be done if this PR were merged is to create a semver compatible tag (eg. `v1.0.2`) that users of this library can pin to.

Note that I set the language version go 1.9 in the mod file because 1.9.7 is the earliest version with partial support for reading the `go.mod` file. If you want to continue to support syntax and APIs from as early as 1.1, I can change it, but the tooling doesn't actually understand these versions yet so to start I just set it to 1.9.

Thank you for your consideration.

[Go Modules]: https://github.com/golang/go/wiki/Modules
[`go.mod`]: https://tip.golang.org/cmd/go/#hdr-The_go_mod_file