### PR TITLE
Fixed issue with default handler for font-family not validating correctly

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -1143,7 +1143,7 @@ func FontFamilyHandler(value string) bool {
 	if in(splitVals, values) {
 		return true
 	}
-	reg := regexp.MustCompile(`('[a-z ]+'|[a-z]+)`)
+	reg := regexp.MustCompile(`('[a-z \-]+'|[a-z \-]+)`)
 	reg.Longest()
 	for _, i := range splitVals {
 		i = strings.TrimSpace(i)

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -510,9 +510,11 @@ func TestDefaultHandlers(t *testing.T) {
 		},
 		{
 			in: `<div style="font-family: 'Times New Roman', Times, ` +
-				`serif"></div>`,
+				`serif"></div><span style="font-family: comic sans ms, ` +
+				`cursive, sans-serif;">aaaaaa</span></span>`,
 			expected: `<div style="font-family: &#39;Times New Roman&#39;,` +
-				` Times, serif"></div>`,
+				` Times, serif"></div><span style="font-family: comic sans` +
+				` ms, cursive, sans-serif">aaaaaa</span></span>`,
 		},
 		{
 			in:       `<div style="font-kerning: normal"></div>`,


### PR DESCRIPTION
Found/fixed an issue with the default handler for the Font-Family css property not working properly in cases including dashes, or spaces when not inside quotes