### PR TITLE
fixes URL sanitization with more than one query parameter

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -158,7 +158,7 @@ func (p *Policy) writeLinkableBuf(buff *bytes.Buffer, token *html.Token) {
 				tokenBuff.WriteString(html.EscapeString(attr.Val))
 				continue
 			}
-			u, err := sanitizedUrl(attr.Val)
+			u, err := sanitizedUrl(u)
 			if err == nil {
 				tokenBuff.WriteString(u)
 			} else {

--- a/sanitize.go
+++ b/sanitize.go
@@ -86,17 +86,11 @@ func (p *Policy) SanitizeReader(r io.Reader) *bytes.Buffer {
 	return p.sanitize(r)
 }
 
+const escapedURLChars = "'<>\"\r"
+
 func escapeUrlComponent(val string) string {
-	const escapedChars = "'<>\"\r"
-
-	type linkWriter interface {
-		io.Writer
-		io.ByteWriter
-		WriteString(string) (int, error)
-	}
-
 	w := bytes.NewBufferString("")
-	i := strings.IndexAny(val, escapedChars)
+	i := strings.IndexAny(val, escapedURLChars)
 	for i != -1 {
 		if _, err := w.WriteString(val[:i]); err != nil {
 			return w.String()
@@ -122,7 +116,7 @@ func escapeUrlComponent(val string) string {
 		if _, err := w.WriteString(esc); err != nil {
 			return w.String()
 		}
-		i = strings.IndexAny(val, escapedChars)
+		i = strings.IndexAny(val, escapedURLChars)
 	}
 	w.WriteString(val)
 	return w.String()

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -128,12 +128,24 @@ func TestLinks(t *testing.T) {
 			expected: `<a href="?q=1" rel="nofollow">`,
 		},
 		{
+			in:       `<a href="?q=1&r=2">`,
+			expected: `<a href="?q=1&r=2" rel="nofollow">`,
+		},
+		{
+			in:       `<a href="?q=1&r=2&s=:foo@">`,
+			expected: `<a href="?q=1&r=2&s=%3Afoo%40" rel="nofollow">`,
+		},
+		{
 			in:       `<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" alt="Red dot" />`,
 			expected: `<img alt="Red dot"/>`,
 		},
 		{
 			in:       `<img src="giraffe.gif" />`,
 			expected: `<img src="giraffe.gif"/>`,
+		},
+		{
+			in:       `<img src="giraffe.gif?height=500&width=500" />`,
+			expected: `<img src="giraffe.gif?height=500&width=500"/>`,
 		},
 	}
 


### PR DESCRIPTION
This fixes URL sanitization when there are more than one query parameter.

This goes deep into how `token.String()` works -- on `html.StartTagToken` tokens like `a` for example, include linkable attributes (`href` for example). 

Explicitly https://github.com/golang/net/blob/master/html/token.go#L100 `token.String()` escapes *all* `&` ampersands regardless of location. Since `&` is a valid query parameter delimiter we need to treat this case specifically.

fixes #88 