### PR TITLE
Sanitize should not add forcibly add values to query components

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -124,8 +124,9 @@ func escapeUrlComponent(val string) string {
 
 // Query represents a query
 type Query struct {
-	Key   string
-	Value string
+	Key      string
+	Value    string
+	HasValue bool
 }
 
 func parseQuery(query string) (values []Query, err error) {
@@ -140,8 +141,10 @@ func parseQuery(query string) (values []Query, err error) {
 			continue
 		}
 		value := ""
+		hasValue := false
 		if i := strings.Index(key, "="); i >= 0 {
 			key, value = key[:i], key[i+1:]
+			hasValue = true
 		}
 		key, err1 := url.QueryUnescape(key)
 		if err1 != nil {
@@ -158,8 +161,9 @@ func parseQuery(query string) (values []Query, err error) {
 			continue
 		}
 		values = append(values, Query{
-			Key:   key,
-			Value: value,
+			Key:      key,
+			Value:    value,
+			HasValue: hasValue,
 		})
 	}
 	return values, err
@@ -169,8 +173,10 @@ func encodeQueries(queries []Query) string {
 	var b strings.Builder
 	for i, query := range queries {
 		b.WriteString(url.QueryEscape(query.Key))
-		b.WriteString("=")
-		b.WriteString(url.QueryEscape(query.Value))
+		if query.HasValue {
+			b.WriteString("=")
+			b.WriteString(url.QueryEscape(query.Value))
+		}
 		if i < len(queries)-1 {
 			b.WriteString("&")
 		}
@@ -964,7 +970,6 @@ func (p *Policy) matchRegex(elementName string) (map[string]attrPolicy, bool) {
 	}
 	return aps, matched
 }
-
 
 // normaliseElementName takes a HTML element like <script> which is user input
 // and returns a lower case version of it that is immune to UTF-8 to ASCII

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -152,8 +152,8 @@ func TestLinks(t *testing.T) {
 			expected: `<img src="giraffe.gif"/>`,
 		},
 		{
-			in:       `<img src="giraffe.gif?height=500&width=500" />`,
-			expected: `<img src="giraffe.gif?height=500&width=500"/>`,
+			in:       `<img src="giraffe.gif?height=500&width=500&flag" />`,
+			expected: `<img src="giraffe.gif?height=500&width=500&flag"/>`,
 		},
 	}
 


### PR DESCRIPTION
Although query components are often key=value pairs - there is no absolute requirement
for the keys to have values and if there is not a value then the equal sign should not
be added.

Fixes go-gitea/gitea#15349

Signed-off-by: Andrew Thornton <art27@cantab.net>