### PR TITLE
Add RequireSandboxOnIFrame

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -295,3 +295,9 @@ func (p *Policy) AllowTables() {
 		CellVerticalAlign,
 	).OnElements("tbody", "tfoot")
 }
+
+func (p *Policy) AllowIFrames(vals ...SandboxValue) {
+	p.AllowAttrs("sandbox").OnElements("iframe")
+
+	p.RequireSandboxOnIFrame(vals...)
+}

--- a/policy.go
+++ b/policy.go
@@ -74,6 +74,9 @@ type Policy struct {
 	// When true, add crossorigin="anonymous" to HTML audio, img, link, script, and video tags
 	requireCrossOriginAnonymous bool
 
+	// When true, add and filter sandbox attribute on iframe tags
+	requireSandboxOnIFrame map[string]bool
+
 	// When true add target="_blank" to fully qualified links
 	// Will add for href="http://foo"
 	// Will skip for href="/foo" or href="foo"
@@ -188,6 +191,25 @@ type stylePolicyBuilder struct {
 }
 
 type urlPolicy func(url *url.URL) (allowUrl bool)
+
+type SandboxValue int64
+
+const (
+	SandboxAllowDownloads SandboxValue = iota
+	SandboxAllowDownloadsWithoutUserActivation
+	SandboxAllowForms
+	SandboxAllowModals
+	SandboxAllowOrientationLock
+	SandboxAllowPointerLock
+	SandboxAllowPopups
+	SandboxAllowPopupsToEscapeSandbox
+	SandboxAllowPresentation
+	SandboxAllowSameOrigin
+	SandboxAllowScripts
+	SandboxAllowStorageAccessByUserActivation
+	SandboxAllowTopNavigation
+	SandboxAllowTopNavigationByUserActivation
+)
 
 // init initializes the maps if this has not been done already
 func (p *Policy) init() {
@@ -678,6 +700,56 @@ func (p *Policy) AllowURLSchemeWithCustomPolicy(
 	p.allowURLSchemes[scheme] = append(p.allowURLSchemes[scheme], urlPolicy)
 
 	return p
+}
+
+func (p *Policy) RequireSandboxOnIFrame(vals ...SandboxValue) {
+	p.requireSandboxOnIFrame = make(map[string]bool)
+
+	for val := range vals {
+		switch SandboxValue(val) {
+		case SandboxAllowDownloads:
+			p.requireSandboxOnIFrame["allow-downloads"] = true
+
+		case SandboxAllowDownloadsWithoutUserActivation:
+			p.requireSandboxOnIFrame["allow-downloads-without-user-activation"] = true
+
+		case SandboxAllowForms:
+			p.requireSandboxOnIFrame["allow-forms"] = true
+
+		case SandboxAllowModals:
+			p.requireSandboxOnIFrame["allow-modals"] = true
+
+		case SandboxAllowOrientationLock:
+			p.requireSandboxOnIFrame["allow-orientation-lock"] = true
+
+		case SandboxAllowPointerLock:
+			p.requireSandboxOnIFrame["allow-pointer-lock"] = true
+
+		case SandboxAllowPopups:
+			p.requireSandboxOnIFrame["allow-popups"] = true
+
+		case SandboxAllowPopupsToEscapeSandbox:
+			p.requireSandboxOnIFrame["allow-popups-to-escape-sandbox"] = true
+
+		case SandboxAllowPresentation:
+			p.requireSandboxOnIFrame["allow-presentation"] = true
+
+		case SandboxAllowSameOrigin:
+			p.requireSandboxOnIFrame["allow-same-origin"] = true
+
+		case SandboxAllowScripts:
+			p.requireSandboxOnIFrame["allow-scripts"] = true
+
+		case SandboxAllowStorageAccessByUserActivation:
+			p.requireSandboxOnIFrame["allow-storage-access-by-user-activation"] = true
+
+		case SandboxAllowTopNavigation:
+			p.requireSandboxOnIFrame["allow-top-navigation"] = true
+
+		case SandboxAllowTopNavigationByUserActivation:
+			p.requireSandboxOnIFrame["allow-top-navigation-by-user-activation"] = true
+		}
+	}
 }
 
 // AddSpaceWhenStrippingTag states whether to add a single space " " when

--- a/policy.go
+++ b/policy.go
@@ -702,6 +702,8 @@ func (p *Policy) AllowURLSchemeWithCustomPolicy(
 	return p
 }
 
+// RequireSandboxOnIFrame will result in all iframe tags having a sandbox="" tag
+// Any sandbox values not specified here will be filtered from the generated HTML
 func (p *Policy) RequireSandboxOnIFrame(vals ...SandboxValue) {
 	p.requireSandboxOnIFrame = make(map[string]bool)
 

--- a/sanitize.go
+++ b/sanitize.go
@@ -240,7 +240,7 @@ func (p *Policy) sanitize(r io.Reader, w io.Writer) error {
 	// rather than:
 	//   p := bluemonday.NewPolicy()
 	// If this is the case, and if they haven't yet triggered an action that
-	// would initiliaze the maps, then we need to do that.
+	// would initialize the maps, then we need to do that.
 	p.init()
 
 	buff, ok := w.(stringWriterWriter)
@@ -806,6 +806,29 @@ attrsLoop:
 				crossOrigin.Val = "anonymous"
 				cleanAttrs = append(cleanAttrs, crossOrigin)
 			}
+		}
+	}
+
+	if p.requireSandboxOnIFrame != nil && elementName == "iframe" {
+		var sandboxFound bool
+		for i, htmlAttr := range cleanAttrs {
+			if htmlAttr.Key == "sandbox" {
+				sandboxFound = true
+				var cleanVals []string
+				for _, val := range strings.Fields(htmlAttr.Val) {
+					if p.requireSandboxOnIFrame[val] {
+						cleanVals = append(cleanVals, val)
+					}
+				}
+				cleanAttrs[i].Val = strings.Join(cleanVals, " ")
+			}
+		}
+
+		if !sandboxFound {
+			sandbox := html.Attribute{}
+			sandbox.Key = "sandbox"
+			sandbox.Val = ""
+			cleanAttrs = append(cleanAttrs, sandbox)
 		}
 	}
 

--- a/sanitize.go
+++ b/sanitize.go
@@ -815,9 +815,13 @@ attrsLoop:
 			if htmlAttr.Key == "sandbox" {
 				sandboxFound = true
 				var cleanVals []string
+				cleanValsSet := make(map[string]bool)
 				for _, val := range strings.Fields(htmlAttr.Val) {
 					if p.requireSandboxOnIFrame[val] {
-						cleanVals = append(cleanVals, val)
+						if !cleanValsSet[val] {
+							cleanVals = append(cleanVals, val)
+							cleanValsSet[val] = true
+						}
 					}
 				}
 				cleanAttrs[i].Val = strings.Join(cleanVals, " ")

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1871,6 +1871,24 @@ func TestIssue107(t *testing.T) {
 	wg.Wait()
 }
 
+func TestIFrameSandbox(t *testing.T) {
+	p := NewPolicy()
+	p.AllowAttrs("sandbox").OnElements("iframe")
+	p.RequireSandboxOnIFrame(SandboxAllowDownloads)
+
+	in := `<iframe src="http://example.com" sandbox="allow-forms allow-downloads"></iframe>`
+	expected := `<iframe sandbox="allow-downloads"></iframe>`
+	out := p.Sanitize(in)
+	if out != expected {
+		t.Errorf(
+			"test failed;\ninput   : %s\noutput  : %s\nexpected: %s",
+			in,
+			out,
+			expected,
+		)
+	}
+}
+
 func TestSanitizedURL(t *testing.T) {
 	tests := []test{
 		{

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1876,7 +1876,7 @@ func TestIFrameSandbox(t *testing.T) {
 	p.AllowAttrs("sandbox").OnElements("iframe")
 	p.RequireSandboxOnIFrame(SandboxAllowDownloads)
 
-	in := `<iframe src="http://example.com" sandbox="allow-forms allow-downloads"></iframe>`
+	in := `<iframe src="http://example.com" sandbox="allow-forms allow-downloads allow-downloads"></iframe>`
 	expected := `<iframe sandbox="allow-downloads"></iframe>`
 	out := p.Sanitize(in)
 	if out != expected {


### PR DESCRIPTION
WIP implementation of `RequireSandboxOnIFrame`.

Open questions:
- Should `RequireSandboxOnIFrame` internally call `p.AllowAttrs("sandbox").OnElements("iframe")`, or should we leave that to the user?
- When an input `<iframe>` does NOT have a `sandbox` attribute, the entire tag is omitted entirely. However, what we actually want to do is keep the tag and enforce a blank `sandbox=""` attribute. (Might be related to #68?)
- This implementation will not dedupe values in the input `sandbox` attribute (ex: `allow-downloads allow-downloads` -> `allow-downloads allow-downloads`). Is that something we should do?

Closes #135