### PR TITLE
Fix incorrect handling of iframe SandboxValues

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -707,7 +707,7 @@ func (p *Policy) AllowURLSchemeWithCustomPolicy(
 func (p *Policy) RequireSandboxOnIFrame(vals ...SandboxValue) {
 	p.requireSandboxOnIFrame = make(map[string]bool)
 
-	for val := range vals {
+	for _, val := range vals {
 		switch SandboxValue(val) {
 		case SandboxAllowDownloads:
 			p.requireSandboxOnIFrame["allow-downloads"] = true

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1874,10 +1874,10 @@ func TestIssue107(t *testing.T) {
 func TestIFrameSandbox(t *testing.T) {
 	p := NewPolicy()
 	p.AllowAttrs("sandbox").OnElements("iframe")
-	p.RequireSandboxOnIFrame(SandboxAllowDownloads)
+	p.RequireSandboxOnIFrame(SandboxAllowForms, SandboxAllowPopups)
 
-	in := `<iframe src="http://example.com" sandbox="allow-forms allow-downloads allow-downloads"></iframe>`
-	expected := `<iframe sandbox="allow-downloads"></iframe>`
+	in := `<iframe src="http://example.com" sandbox="allow-forms allow-downloads allow-downloads allow-popups"></iframe>`
+	expected := `<iframe sandbox="allow-forms allow-popups"></iframe>`
 	out := p.Sanitize(in)
 	if out != expected {
 		t.Errorf(


### PR DESCRIPTION
Follow up fix for https://github.com/microcosm-cc/bluemonday/pull/136.

`RequireSandboxOnIFrame` was incorrectly using the _index_ of the passed in sandbox values instead of the actual value. :/