### PR TITLE
Don't write self-closing tag with empty attributes

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -440,8 +440,8 @@ func (p *Policy) sanitize(r io.Reader, w io.Writer) error {
 					if _, err := buff.WriteString(" "); err != nil {
 						return err
 					}
-					break
 				}
+				break
 			}
 			if !skipElementContent {
 				if _, err := buff.WriteString(token.String()); err != nil {

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -3913,3 +3913,21 @@ func TestIssue147(t *testing.T) {
 			expected)
 	}
 }
+
+func TestRemovingEmptySelfClosingTag(t *testing.T) {
+	p := NewPolicy()
+
+	// Only broke when attribute policy was specified.
+	p.AllowAttrs("type").OnElements("input")
+
+	input := `<input/>`
+	out := p.Sanitize(input)
+	expected := ``
+	if out != expected {
+		t.Errorf(
+			"test failed;\ninput   : %s\noutput  : %s\nexpected: %s",
+			input,
+			out,
+			expected)
+	}
+}


### PR DESCRIPTION
- Currently the code will write self-closing tags with empty attributes to the output, even when the element isn't allowed to have empty attributes.
- Move to `break` to one outer scope to fix it.