### PR TITLE
Add callback function when parsing the attributes of an element

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -497,6 +497,10 @@ func (p *Policy) sanitizeAttrs(
 	aps map[string][]attrPolicy,
 ) []html.Attribute {
 
+	if p.callbackAttr != nil {
+		attrs = p.callbackAttr(elementName, attrs)
+	}
+
 	if len(attrs) == 0 {
 		return attrs
 	}


### PR DESCRIPTION
Add callback function when parsing the attributes of an element. 
The callback function that will be called whenever element's attributes are parsed. If the callback returns nil or empty array of html attributes then the attributes will not be included in the output. The callback function, if non-nil, will be called before any filtering of the attributes is done.