### PR TITLE
Upgrade golang.org/x/net to 0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aymerick/douceur v0.2.0
-	golang.org/x/net v0.0.0-20221002022538-bcab6841153b
+	golang.org/x/net v0.8.0
 )
 
 require github.com/gorilla/css v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,5 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
 github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
-golang.org/x/net v0.0.0-20221002022538-bcab6841153b h1:6e93nYa3hNqAvLr0pD4PN1fFS+gKzp2zAXqrnTCstqU=
-golang.org/x/net v0.0.0-20221002022538-bcab6841153b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
+golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1612,7 +1612,7 @@ func TestComments(t *testing.T) {
 		// for every user of bluemonday that utilises .AllowComments()
 		{
 			in:       `<!--[if gte mso 9]>Hello<![endif]-->`,
-			expected: `<!--[if gte mso 9]&gt;Hello&lt;![endif]-->`,
+			expected: `<!--[if gte mso 9]>Hello<![endif]-->`,
 		},
 	}
 


### PR DESCRIPTION
Upgrade (to at least 0.7.0+) needed because of CVE-2022-41723

0.8.0 satisfies the original test that was changed in https://github.com/microcosm-cc/bluemonday/pull/148/files
