### PR TITLE
Fix parsing style attribute with trailing spaces

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -852,6 +852,7 @@ func (p *Policy) sanitizeStyles(attr html.Attribute, elementName string) html.At
 	}
 
 	//Add semi-colon to end to fix parsing issue
+	attr.Val = strings.TrimRight(attr.Val, " ")
 	if len(attr.Val) > 0 && attr.Val[len(attr.Val)-1] != ';' {
 		attr.Val = attr.Val + ";"
 	}

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -3965,3 +3965,23 @@ func TestIssue161(t *testing.T) {
 			expected)
 	}
 }
+
+func TestIssue171(t *testing.T) {
+	// https://github.com/microcosm-cc/bluemonday/issues/171
+	//
+	// Trailing spaces in the style attribute should not cause the value to be omitted
+	p := UGCPolicy()
+	p.AllowAttrs("style").OnElements("p")
+	p.AllowStyles("color", "text-align").OnElements("p")
+
+	input := `<p style="color: red; text-align: center;   "></p>`
+	out := p.Sanitize(input)
+	expected := `<p style="color: red; text-align: center"></p>`
+	if out != expected {
+		t.Errorf(
+			"test failed;\ninput   : %s\noutput  : %s\nexpected: %s",
+			input,
+			out,
+			expected)
+	}
+}


### PR DESCRIPTION
Fixes #171 

Since I'm not sure about the origin of the rule `Add semi-colon to end to fix parsing issue`, I simply added trimming of the trailing spaces.