### PR TITLE
Added src rewriter

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -121,6 +121,11 @@ type Policy struct {
 	// if one would want to allow all URL schemes, they would add `.+`
 	allowURLSchemeRegexps []*regexp.Regexp
 
+	// If srcRewriter is not nil, it is used to rewrite the src attribute
+	// of tags that download resources, such as <img> and <script>.
+	// It requires that the URL is parsable by "net/url" url.Parse().
+	srcRewriter urlRewriter
+
 	// If an element has had all attributes removed as a result of a policy
 	// being applied, then the element would be removed from the output.
 	//
@@ -195,6 +200,8 @@ type stylePolicyBuilder struct {
 }
 
 type urlPolicy func(url *url.URL) (allowUrl bool)
+
+type urlRewriter func(*url.URL)
 
 type SandboxValue int64
 
@@ -572,6 +579,13 @@ func (p *Policy) AllowElementsMatching(regex *regexp.Regexp) *Policy {
 // match a regexp.
 func (p *Policy) AllowURLSchemesMatching(r *regexp.Regexp) *Policy {
 	p.allowURLSchemeRegexps = append(p.allowURLSchemeRegexps, r)
+	return p
+}
+
+// RewriteSrc will rewrite the src attribute of a resource downloading tag
+// (e.g. <img>, <script>, <iframe>) using the provided function.
+func (p *Policy) RewriteSrc(fn urlRewriter) *Policy {
+	p.srcRewriter = fn
 	return p
 }
 

--- a/policy.go
+++ b/policy.go
@@ -584,6 +584,10 @@ func (p *Policy) AllowURLSchemesMatching(r *regexp.Regexp) *Policy {
 
 // RewriteSrc will rewrite the src attribute of a resource downloading tag
 // (e.g. <img>, <script>, <iframe>) using the provided function.
+//
+// For a mail provider, this can be used to proxify requests and prevent
+// the sender from learning the IP address of the recipient and / or
+// whether the recipient has opened the email (and when / how often).
 func (p *Policy) RewriteSrc(fn urlRewriter) *Policy {
 	p.srcRewriter = fn
 	return p

--- a/sanitize.go
+++ b/sanitize.go
@@ -612,6 +612,14 @@ attrsLoop:
 				case "audio", "embed", "iframe", "img", "script", "source", "track", "video":
 					if htmlAttr.Key == "src" {
 						if u, ok := p.validURL(htmlAttr.Val); ok {
+							if p.srcRewriter != nil {
+								parsedURL, err := url.Parse(u)
+								if err != nil {
+									fmt.Println(err)
+								}
+								p.srcRewriter(parsedURL)
+								u = parsedURL.String()
+							}
 							htmlAttr.Val = u
 							tmpAttrs = append(tmpAttrs, htmlAttr)
 						}

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -150,16 +150,27 @@ func TestLinks(t *testing.T) {
 		},
 		{
 			in:       `<img src="giraffe.gif" />`,
-			expected: `<img src="giraffe.gif"/>`,
+			expected: `<img src="https://proxy.example.com/?u=giraffe.gif"/>`,
 		},
 		{
 			in:       `<img src="giraffe.gif?height=500&amp;width=500&amp;flag" />`,
-			expected: `<img src="giraffe.gif?height=500&amp;width=500&amp;flag"/>`,
+			expected: `<img src="https://proxy.example.com/?u=giraffe.gif?height=500&amp;width=500&amp;flag"/>`,
 		},
 	}
 
 	p := UGCPolicy()
 	p.RequireParseableURLs(true)
+	p.RewriteSrc(func(u *url.URL) {
+		// Proxify all requests to "https://proxy.example.com/?u=http://example.com/"
+		// This is a contrived example, but it shows how to rewrite URLs
+		// to proxy all requests through a single URL.
+
+		url := u.String()
+		u.Scheme = "https"
+		u.Host = "proxy.example.com"
+		u.Path = "/"
+		u.RawQuery = "u=" + url
+	})
 
 	// These tests are run concurrently to enable the race detector to pick up
 	// potential issues


### PR DESCRIPTION
Allows for people to rewrite src tags.
Useful to proxify request and anonymize a client's data for example. (How gmail rewrites them)