### PR TITLE
Prefer explicit rules over regexp

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -118,7 +118,11 @@ type Policy struct {
 	allowURLSchemes map[string][]urlPolicy
 
 	// These regexps are used to match allowed URL schemes, for example
-	// if one would want to allow all URL schemes, they would add `.+`
+	// if one would want to allow all URL schemes, they would add `.+`.
+	// However pay attention as this can lead to XSS being rendered thus
+	// defeating the purpose of using a HTML sanitizer.
+	// The regexps are only considered if a schema was not explicitly
+	// handled by `AllowURLSchemes` or `AllowURLSchemeWithCustomPolicy`.
 	allowURLSchemeRegexps []*regexp.Regexp
 
 	// If an element has had all attributes removed as a result of a policy

--- a/sanitize.go
+++ b/sanitize.go
@@ -970,14 +970,14 @@ func (p *Policy) validURL(rawurl string) (string, bool) {
 		}
 
 		if u.Scheme != "" {
-			for _, r := range p.allowURLSchemeRegexps {
-				if r.MatchString(u.Scheme) {
-					return u.String(), true
-				}
-			}
-
 			urlPolicies, ok := p.allowURLSchemes[u.Scheme]
 			if !ok {
+				for _, r := range p.allowURLSchemeRegexps {
+					if r.MatchString(u.Scheme) {
+						return u.String(), true
+					}
+				}
+
 				return "", false
 			}
 

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -4007,4 +4007,22 @@ func TestIssue174(t *testing.T) {
 			out,
 			expected)
 	}
+
+	// Custom handling of specific URL schemes even if the regex allows all
+	p.AllowURLSchemeWithCustomPolicy("javascript", func(*url.URL) bool {
+		return false
+	})
+
+	input = `<a href="cbthunderlink://somebase64string"></a>
+<a href="javascript:alert('test')">xss</a>`
+	out = p.Sanitize(input)
+	expected = `<a href="cbthunderlink://somebase64string" rel="nofollow"></a>
+xss`
+	if out != expected {
+		t.Errorf(
+			"test failed;\ninput   : %s\noutput  : %s\nexpected: %s",
+			input,
+			out,
+			expected)
+	}
 }


### PR DESCRIPTION
#175 introduced a potential dangerous change. If a user registers the regexp `.+` for scheme validation (as written in the comment) to allow all possible schemes, a link like `<a href="javascript:...">` is valid too. The Go regexp module does not implement negative lookaheads, so you can't write "all but xyz" (`(?!javascript|vbscript)`).

This PR moves the regexp check a little bit down to be only executed if there was no other explicit scheme registration was found. So now
```go
p.AllowURLSchemesMatching(regexp.MustCompile(`.+`))
p.AllowURLSchemeWithCustomPolicy("javascript", func(*url.URL) bool {
	return false
})
```
will allow every scheme but `javascript`.

An alternative would be to drop `AllowURLSchemesMatching` again and add methods `DisallowURLSchemes` and `DisallowURLSchemeWithCustomPolicy`.