### PR TITLE
Revert dependency on Go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microcosm-cc/bluemonday
 
-go 1.21
+go 1.19
 
 require (
 	github.com/aymerick/douceur v0.2.0


### PR DESCRIPTION
https://github.com/microcosm-cc/bluemonday/commit/a50ca5f2e53d33247f60655e1ed76803fc61d26d updated `go.mod` to specify the minimum Go version to be Go 1.21. This is not necessary (the module compiles with earlier versions of Go) and has the unwanted side-effect of setting the minimum version of Go to 1.21 for all projects that depend on this module, directly or indirectly.

Since Go 1.21 is not actually required, this PR reverts the minimum Go version to 1.19.