### PR TITLE
Support four-value syntax for CSS hex color

### DIFF
--- a/css/handlers.go
+++ b/css/handlers.go
@@ -291,7 +291,7 @@ var (
 	Font              = regexp.MustCompile(`^('[a-z \-]+'|[a-z \-]+)$`)
 	Grayscale         = regexp.MustCompile(`^grayscale\(([0-9]{1,2}|100)%\)$`)
 	GridTemplateAreas = regexp.MustCompile(`^['"]?[a-z ]+['"]?$`)
-	HexRGB            = regexp.MustCompile(`^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$`)
+	HexRGB            = regexp.MustCompile(`^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$`)
 	HSL               = regexp.MustCompile(`^hsl\([ ]*([012]?[0-9]{1,2}|3[0-5][0-9]|360),[ ]*([0-9]{0,2}|100)\%,[ ]*([0-9]{0,2}|100)\%\)$`)
 	HSLA              = regexp.MustCompile(`^hsla\(([ ]*[012]?[0-9]{1,2}|3[0-5][0-9]|360),[ ]*([0-9]{0,2}|100)\%,[ ]*([0-9]{0,2}|100)\%,[ ]*(1|1\.0|0|(0\.[0-9]+))\)$`)
 	HueRotate         = regexp.MustCompile(`^hue-rotate\(([12]?[0-9]{1,2}|3[0-5][0-9]|360)?\)$`)

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -2029,6 +2029,10 @@ func TestDefaultStyleHandlers(t *testing.T) {
 			expected: `<div style="column-rule-color: #ff00ff"></div>`,
 		},
 		{
+			in:       `<div style="column-rule-color: #f0ff;"></div>`,
+			expected: `<div style="column-rule-color: #f0ff"></div>`,
+		},
+		{
 			in:       `<div style="column-rule: red;"></div>`,
 			expected: `<div style="column-rule: red"></div>`,
 		},


### PR DESCRIPTION
Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color

> #RGB        // The three-value syntax
#RGBA       // The four-value syntax
#RRGGBB     // The six-value syntax
#RRGGBBAA   // The eight-value syntax