### PR TITLE
Adds support for transparent color value for *-color attributes

### DIFF
--- a/css/handlers.go
+++ b/css/handlers.go
@@ -250,9 +250,9 @@ var (
 		"writing-mode":               WritingModeHandler,
 		"z-index":                    ZIndexHandler,
 	}
-	colorValues = []string{"initial", "inherit", "aliceblue", "antiquewhite",
-		"aqua", "aquamarine", "azure", "beige", "bisque", "black",
-		"blanchedalmond", "blue", "blueviolet", "brown", "burlywood",
+	colorValues = []string{"transparent", "initial", "inherit", "aliceblue",
+		"antiquewhite", "aqua", "aquamarine", "azure", "beige", "bisque",
+		"black", "blanchedalmond", "blue", "blueviolet", "brown", "burlywood",
 		"cadetblue", "chartreuse", "chocolate", "coral", "cornflowerblue",
 		"cornsilk", "crimson", "cyan", "darkblue", "darkcyan", "darkgoldenrod",
 		"darkgray", "darkgrey", "darkgreen", "darkkhaki", "darkmagenta",

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1748,6 +1748,10 @@ func TestDefaultStyleHandlers(t *testing.T) {
 			expected: `<div style="background-color: coral"></div>`,
 		},
 		{
+			in:       `<div style="background-color: transparent"></div>`,
+			expected: `<div style="background-color: transparent"></div>`,
+		},
+		{
 			in: `<div style="background-image: url('http://paper.gif')">` +
 				`</div><div style="background-image: inherit"></div>`,
 			expected: `<div style="background-image: ` +


### PR DESCRIPTION
# Description

Was doing some sanitization on inputs and noticed that the sanitization behaviour was not allowing for `background-color: transparent` so I decided to open up a pull request to add support. Note this is a valid value for a color as seen in the follow html specifications:

https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#formal_syntax
https://developer.mozilla.org/en-US/docs/Web/CSS/named-color#transparent

# Temporary work around

Until support is added I'm currently relying on the following work around incase anyone else arrives here before the patch lands.

```go
...
p.AllowStyles("background-color").MatchingEnum("transparent").OnElements(...)
...
```