### PR TITLE
Bump golang.org/x/net to v0.45.0 to fix vulnerability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,24 +7,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [1.19.x, 1.x]
+        go: [1.24.x, 1.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Install Go ${{ matrix.go }}
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ matrix.go }}
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
+    - name: Install Go ${{ matrix.go }}
+      uses: actions/setup-go@v6
+      with:
+        go-version: ${{ matrix.go }}
     - name: Vet
       run: go vet ./...
     - name: Staticcheck
       run: |
-        go install honnef.co/go/tools/cmd/staticcheck@latest
+        go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
         staticcheck ./...
     - name: Test
       run: go test -v -race ./...
-
+    - name: Govulncheck
+      run: |
+        go install golang.org/x/vuln/cmd/govulncheck@latest
+        govulncheck ./...

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/microcosm-cc/bluemonday
 
-go 1.19
+go 1.24.0
 
 require (
 	github.com/aymerick/douceur v0.2.0
-	golang.org/x/net v0.26.0
+	golang.org/x/net v0.45.0
 )
 
 require github.com/gorilla/css v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,5 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
 github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
-golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
-golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
+golang.org/x/net v0.45.0 h1:RLBg5JKixCy82FtLJpeNlVM0nrSqpCRYzVU1n8kj0tM=
+golang.org/x/net v0.45.0/go.mod h1:ECOoLqd5U3Lhyeyo/QDCEVQ4sNgYsqvCZ722XogGieY=


### PR DESCRIPTION
Running [govulncheck](https://go.dev/blog/govulncheck) before:

```console
❯ govulncheck ./...
=== Symbol Results ===

Vulnerability #1: GO-2025-3595
    Incorrect Neutralization of Input During Web Page Generation in x/net in
    golang.org/x/net
  More info: https://pkg.go.dev/vuln/GO-2025-3595
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.26.0
    Fixed in: golang.org/x/net@v0.38.0
    Example traces found:
      #1: sanitize.go:226:20: bluemonday.Policy.sanitize calls html.Tokenizer.Next

Your code is affected by 1 vulnerability from 1 module.
This scan also found 3 vulnerabilities in packages you import and 1
vulnerability in modules you require, but your code doesn't appear to call these
vulnerabilities.
Use '-show verbose' for more details.
```

After upgrading to golang.org/x/net@v0.38.0 and Go 1.23.0:

```console
❯ go install golang.org/x/vuln/cmd/govulncheck@latest
❯ govulncheck ./...
=== Symbol Results ===

Vulnerability #1: GO-2025-4010
    Insufficient validation of bracketed IPv6 hostnames in net/url
  More info: https://pkg.go.dev/vuln/GO-2025-4010
  Standard library
    Found in: net/url@go1.23.12
    Fixed in: net/url@go1.24.8
    Example traces found:
Error:       #1: sanitize.go:583:36: bluemonday.Policy.sanitizeAttrs calls url.Parse

Your code is affected by 1 vulnerability from the Go standard library.
This scan also found 3 vulnerabilities in packages you import and 14
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
```

After upgrading to golang.org/x/net@v0.45.0 and Go 1.24.0:

```console
❯ govulncheck ./...
No vulnerabilities found.
```