### PR TITLE
fix: memoize css.recursiveCheck to remove exponential-time CSS DoS

### DIFF
--- a/css/handlers.go
+++ b/css/handlers.go
@@ -337,16 +337,32 @@ func multiSplit(value string, seps ...string) []string {
 	return curArray
 }
 
+// recursiveCheck reports whether value can be split, in order, into groups
+// of tokens each accepted by one of funcs. The outcome depends only on how
+// many tokens remain, so memoizing on that length keeps the search
+// polynomial without changing which values are accepted.
 func recursiveCheck(value []string, funcs []func(string) bool) bool {
+	memo := make(map[int]bool, len(value))
+	return recursiveCheckMemo(value, funcs, memo)
+}
+
+func recursiveCheckMemo(value []string, funcs []func(string) bool, memo map[int]bool) bool {
+	if cached, ok := memo[len(value)]; ok {
+		return cached
+	}
+	result := false
+outer:
 	for i := 0; i < len(value); i++ {
 		tempVal := strings.Join(value[:i+1], " ")
 		for _, j := range funcs {
-			if j(tempVal) && (len(value[i+1:]) == 0 || recursiveCheck(value[i+1:], funcs)) {
-				return true
+			if j(tempVal) && (len(value[i+1:]) == 0 || recursiveCheckMemo(value[i+1:], funcs, memo)) {
+				result = true
+				break outer
 			}
 		}
 	}
-	return false
+	memo[len(value)] = result
+	return result
 }
 
 func in(value []string, arr []string) bool {

--- a/css/handlers_test.go
+++ b/css/handlers_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2019, David Kitchen <david@buro9.com>
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the organisation (Microcosm) nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package css
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Regression test for https://github.com/microcosm-cc/bluemonday/issues/225.
+// Whitespace-only tokens give recursiveCheck many equally valid split points;
+// unmemoized it re-explored each one, taking ~4s for the value below. The
+// verdict is unchanged (rejected either way), only the time to reach it.
+func TestIssue225(t *testing.T) {
+	// 20 blank tokens, as the issue #225 payload produced them.
+	pathological := "normal\n" + strings.Repeat(" ", 20) + "16px\nroboto"
+
+	const deadline = 3 * time.Second
+	const want = false
+
+	result := make(chan bool, 1)
+	go func() {
+		result <- FontHandler(pathological)
+	}()
+
+	select {
+	case got := <-result:
+		if got != want {
+			t.Errorf("FontHandler(%q) = %v, want %v", pathological, got, want)
+		}
+	case <-time.After(deadline):
+		t.Fatalf("FontHandler did not return within %v for a 20-blank-token "+
+			"value; recursiveCheck may have regressed to exponential-time "+
+			"behaviour (see issue #225)", deadline)
+	}
+}
+
+// Memoization must not change which values FontHandler accepts, only how
+// fast it decides. Expectations captured from the pre-fix behaviour.
+func TestIssue225AcceptanceUnchanged(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		// Valid "font" shorthand values.
+		{"italic bold 12px/30px Georgia, serif", true},
+		{"icon", true},
+		{"caption", true},
+		{"normal 16px Roboto", true},
+		{"bold 16px/1.5 Arial, sans-serif", true},
+		// Invalid/unsafe values that must stay rejected.
+		{"expression(alert(1))", false},
+		{"javascript:alert(1)", false},
+		{"url(evil.com)", false},
+	}
+	for _, tt := range tests {
+		if got := FontHandler(tt.value); got != tt.want {
+			t.Errorf("FontHandler(%q) = %v, want %v", tt.value, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION

## Problem

Shorthand CSS style handlers (`FontHandler` and roughly a dozen siblings
such as `BackgroundHandler`, `BorderHandler`, `AnimationHandler`,
`FlexHandler`, `BorderImageHandler`, `BorderRadiusHandler`,
`BorderSpacingHandler`, `BorderStyleHandler`, `BorderWidthHandler`,
`ColumnRuleHandler`, `ColumnsHandler`, `BoxShadowHandler` ...) tokenize a
CSS value with `strings.Split(value, " ")` and hand the tokens to
`css.recursiveCheck`, which searches for a way to partition the token
list, in order, into contiguous groups such that every group is accepted
by at least one of a handful of per-property validator functions.

That search was unmemoized. Every recursive call is made on a suffix of
the original token slice, and the boolean result for a given suffix
depends only on how many tokens remain in it (the set of validator
functions is constant throughout one call). Without caching, the same
suffix is re-explored once for every distinct partition path that reaches
it. When a value has several tokens that more than one validator accepts
on their own, the number of such paths grows combinatorially with the
number of tokens, and the wall-clock cost roughly doubles for every extra
token.

This is user-reachable: any value passed through a shorthand style
property (e.g. `style="font: ..."`) that a caller has allowed via
`Policy.AllowStyles` is sanitized through this code path. This is already
reported upstream as **issue #225** ("Unreasonably long sanitization"),
filed 2026-06-26, with a similar font-shorthand-with-indentation repro
and no linked fix.

In practice, a value like the one below - a CSS declaration whose value
is indented over several lines, which puts a run of blank-ish tokens
(runs of space characters that land next to a newline) between two real
tokens - triggers the blow-up. That happens because `FontFamilyHandler`
treats a token that trims down to the empty string as a (vacuously valid)
empty font-family entry, so every one of those blank tokens is a
validator match, i.e. a valid split point, giving `recursiveCheck` a
large number of equally valid ways to partition the run.

```html
<div style="font:
    normal
               16px
    Roboto;"></div>
```

## Root cause

`css/handlers.go:340-350` (pre-fix):

```go
func recursiveCheck(value []string, funcs []func(string) bool) bool {
	for i := 0; i < len(value); i++ {
		tempVal := strings.Join(value[:i+1], " ")
		for _, j := range funcs {
			if j(tempVal) && (len(value[i+1:]) == 0 || recursiveCheck(value[i+1:], funcs)) {
				return true
			}
		}
	}
	return false
}
```

Called from (non-exhaustive): `AnimationHandler`, `BackgroundHandler`,
`BorderHandler`, `BorderSideHandler`, `BorderImageHandler`,
`BorderRadiusHandler`, `BorderSpacingHandler`, `BorderStyleHandler`,
`BorderWidthHandler`, `BoxShadowHandler`, `ColumnRuleHandler`,
`ColumnsHandler`, `FlexHandler`, `FontHandler` (all in `css/handlers.go`).

## Reproduction (measured on the vulnerable revision, commit

`aba082a57c7522316c772ab0dec7e5dbc9833bfa`, before this fix)

Full pipeline (`bluemonday.UGCPolicy().AllowStyles("font").Globally()`,
`Policy.Sanitize`), varying only the amount of indentation before `16px`
in the payload shown above:

```
issue225 baseline elapsed=558.451853ms
indent= 5 elapsed=433.452µs
indent=10 elapsed=14.025727ms
indent=14 elapsed=239.622247ms
indent=15 elapsed=463.134543ms
indent=16 elapsed=917.498235ms
indent=17 elapsed=1.89842383s
indent=18 elapsed=4.038768118s
indent=19 elapsed=8.044745002s
indent=20 elapsed=15.384945008s
```

Cost roughly doubles per extra space of indentation (ratios between
consecutive rows: 1.98x, 2.07x, 2.13x, 1.99x, 1.91x), consistent with
exponential growth in the number of tokens. A single `<div>` with an
~80-character `style` attribute takes over 15 seconds of CPU time to
sanitize; the trend makes a modest increase in indentation (a few dozen
more bytes) enough to hang a request thread indefinitely. This is an
algorithmic-complexity DoS: a tiny, attacker-controlled `style` value can
tie up a server that sanitizes untrusted HTML.

Calling `css.FontHandler` directly (bypassing the HTML/CSS-attribute
parsing layer) with the equivalent token stream confirms `recursiveCheck`
itself is the hot path and that the exponential cost is independent of
whether the value is ultimately accepted or rejected: `FontHandler` in
this case returns `false` (the malformed `16px` token, still carrying a
literal newline, never validates) only after ~4s of work.

## Fix

`css/handlers.go` (see diff): split `recursiveCheck` into a thin wrapper
that allocates a `map[int]bool` memo table, and `recursiveCheckMemo`,
which is the original search plus a cache lookup/store keyed by
`len(value)`.

This is safe because every recursive call is made on `value[i+1:]`, a
suffix of the slice the top-level `recursiveCheck` call was given, and
distinct suffixes of a given slice always have distinct lengths, so
`len(value)` is a valid, collision-free memoization key for one
`recursiveCheck` call's whole search tree. A fresh memo map is allocated
per top-level call, so there is no cross-call state and no behavior
change versus the original algorithm - only redundant recomputation is
eliminated. `recursiveCheck`'s exported signature and all ~12 call sites
are unchanged.

**Complexity**: for a value with N tokens and F validator functions,
there are at most N distinct suffixes, and evaluating one suffix of
length L still costs O(L) split-point checks each doing O(L) work for
`strings.Join` plus O(F) validator calls, i.e. O(L^2 * F) per suffix.
Summed over all suffixes, that is O(N^3 * F) total - polynomial, versus
the unbounded/exponential cost before the fix. Measured effect: the
20-space-indent payload above drops from 15.38s to ~177µs (roughly
87,000x). Even a much larger, non-realistic payload (2000 spaces of
indentation, 100x the original) completes in ~8.6s rather than hanging
indefinitely, and the measured growth from 20 to 2000 tokens is
consistent with the cubic bound above rather than exponential.

**Behavior preservation**: the fix does not alter any validator function
or which values are accepted/rejected - it only caches the final boolean
outcome per suffix. `go test ./...` (all pre-existing tests, including
the full `TestStyling` table in `sanitize_test.go` which already covers
`font`, `font-family`, and 190+ other property/value combinations)
passes unchanged.

## Regression test

`css/handlers_test.go` (new file - the `css` package previously had no
tests):

- `TestIssue225`: calls `FontHandler` with a value containing 20
  blank/whitespace tokens (the same shape as the issue #225 payload) on
  a background goroutine and asserts it returns within a 3-second
  deadline (comfortably above the fixed run's ~microsecond cost, and
  comfortably below the ~4s the unfixed code takes on this exact value).
  It also asserts the returned boolean (`false`) is unchanged from the
  pre-fix behavior, confirmed by running this exact input against the
  unfixed code.
- `TestIssue225AcceptanceUnchanged`: table test asserting `FontHandler`'s
  accept/reject verdict for a set of representative valid `font`
  shorthand values (matching cases already covered in
  `sanitize_test.go`'s `TestStyling`, plus a couple more) and
  representative invalid/unsafe values, to guard against the fix
  accidentally changing acceptance semantics.
